### PR TITLE
Adapt `script helper` to behaviour as documented

### DIFF
--- a/lib.star
+++ b/lib.star
@@ -36,6 +36,21 @@ def script(name, *lines):
     }
 
 
+def background(name, *lines):
+    """Variation of `script`, but runs in background
+    https://cirrus-ci.org/guide/writing-tasks/#background-script-instruction
+    """
+    return {name + '_background_script': lines}
+
+
+def powershell(name, *lines):
+    """Variation of `script`, but uses PowerShell for Windows containers.
+    https://cirrus-ci.org/guide/windows/#powershell-support
+    """
+    instructions = [{"ps": l} for l in lines]
+    return {name + '_script': instructions}
+
+
 def artifacts(name, path, type="", format=""):
     result = {
         'path': path,
@@ -46,6 +61,22 @@ def artifacts(name, path, type="", format=""):
         result['format'] = format
     return {
         name + '_artifacts': result
+    }
+
+
+def file_from_env(var, path, name=""):
+    """Create a file from an environment variable (specially useful with encrypted vars).
+    This function automatically derives the instruction name from the variable name
+    (e.g.: `var=SERVER_CONFIG` will create a `server_config_file` instruction),
+    unless the `name` argument is given (e.g. `name=servercfg` will create a `servercfg_file` instruction).
+    https://cirrus-ci.org/guide/writing-tasks/#file-instruction
+    """
+    name = var.lower() if name == "" else name
+    return {
+        ("%s_file" % name): {
+            "path": path,
+            "variable_name": var
+        }
     }
 
 

--- a/lib.star
+++ b/lib.star
@@ -31,22 +31,27 @@ def cache(name, folder, fingerprint_script=[], populate_script=[]):
 
 
 def script(name, *lines):
-    return {
-        name + '_script': lines
-    }
+    if len(lines) > 0:
+        return {name + '_script': lines}
+    return {'script': name}
 
 
 def background(name, *lines):
     """Variation of `script`, but runs in background
     https://cirrus-ci.org/guide/writing-tasks/#background-script-instruction
     """
-    return {name + '_background_script': lines}
+    if len(lines) > 0:
+        return {name + '_background_script': lines}
+    return {'background_script': name}
 
 
 def powershell(name, *lines):
     """Variation of `script`, but uses PowerShell for Windows containers.
     https://cirrus-ci.org/guide/windows/#powershell-support
     """
+    if len(lines) == 0:
+        return {'script': [{"ps": name}]}
+
     instructions = [{"ps": l} for l in lines]
     return {name + '_script': instructions}
 

--- a/lib.star
+++ b/lib.star
@@ -49,7 +49,8 @@ def artifacts(name, path, type="", format=""):
     }
 
 
-def container(image="", dockerfile="", cpu=2.0, memory=4096):
+def container(image="", dockerfile="", cpu=2.0, memory=4096, **kwargs):
+    """https://cirrus-ci.org/guide/linux"""
     result = dict()
     if image != "":
         result['image'] = image
@@ -57,9 +58,36 @@ def container(image="", dockerfile="", cpu=2.0, memory=4096):
         result['dockerfile'] = dockerfile
     result['cpu'] = cpu
     result['memory'] = memory
+    result.update(kwargs)
     return {
         'container': result
     }
+
+
+def windows_container(image="cirrusci/windowsservercore", os_version="", **kwargs):
+    """https://cirrus-ci.org/guide/windows"""
+    spec = {"image": image}
+    if os_version != "":
+        spec["os_version"] = os_version
+    spec.update(kwargs)
+    return {"windows_container": spec}
+
+
+def macos_instance(image, **kwargs):
+    """https://cirrus-ci.org/guide/macOS"""
+    spec = {"image": image}
+    spec.update(kwargs)
+    return {"macos_instance": spec}
+
+
+def freebsd_instance(image_family="", image_name="", **kwargs):
+    """https://cirrus-ci.org/guide/FreeBSD"""
+    spec = dict(kwargs)
+    if image_family != "":
+        spec["image_family"] = image_family
+    if image_name != "":
+        spec["image_name"] = image_name
+    return {"freebsd_instance": spec}
 
 
 def always(instruction):

--- a/lib.star
+++ b/lib.star
@@ -113,7 +113,7 @@ def macos_instance(image, **kwargs):
 
 def freebsd_instance(image_family="", image_name="", **kwargs):
     """https://cirrus-ci.org/guide/FreeBSD"""
-    spec = dict(kwargs)
+    spec = dict(kwargs.items())
     if image_family != "":
         spec["image_family"] = image_family
     if image_name != "":

--- a/tests/freebsd_instance/.cirrus.expected.yml
+++ b/tests/freebsd_instance/.cirrus.expected.yml
@@ -1,0 +1,8 @@
+task:
+  name: freebsd task
+  freebsd_instance:
+    image_family: freebsd-13-0
+task:
+  name: freebsd task with image_name
+  freebsd_instance:
+    image_name: family/freebsd-13-0

--- a/tests/freebsd_instance/.cirrus.star
+++ b/tests/freebsd_instance/.cirrus.star
@@ -1,0 +1,8 @@
+load("../../lib.star", "task", "freebsd_instance")
+
+def main(ctx):
+    return [
+        task("freebsd task", freebsd_instance("freebsd-13-0")),
+        task("freebsd task with image_name",
+             freebsd_instance(image_name="family/freebsd-13-0")),
+    ]

--- a/tests/instructions/file_from_env/.cirrus.expected.yml
+++ b/tests/instructions/file_from_env/.cirrus.expected.yml
@@ -1,0 +1,20 @@
+task:
+  name: test file_from_env
+  env:
+    DOCKER_CONFIG: ENCRYPTED[qwerty]
+  container:
+    cpu: 2
+    memory: 4096
+  docker_config_file:
+    path: /root/.docker/config
+    variable_name: DOCKER_CONFIG
+task:
+  name: test named file_from_env
+  env:
+    DOCKER_CONFIG: ENCRYPTED[qwerty]
+  container:
+    cpu: 2
+    memory: 4096
+  mydocker_file:
+    path: /root/.docker/config
+    variable_name: DOCKER_CONFIG

--- a/tests/instructions/file_from_env/.cirrus.star
+++ b/tests/instructions/file_from_env/.cirrus.star
@@ -1,0 +1,25 @@
+load("../../../lib.star", "task", "container", "file_from_env")
+
+def main(ctx):
+    return [
+        task(
+            "test file_from_env",
+            container(),
+            env=dict(DOCKER_CONFIG="ENCRYPTED[qwerty]"),
+            instructions=[
+               file_from_env("DOCKER_CONFIG", "/root/.docker/config"),
+            ]
+        ),
+        task(
+            "test named file_from_env",
+            container(),
+            env=dict(DOCKER_CONFIG="ENCRYPTED[qwerty]"),
+            instructions=[
+               file_from_env(
+                   name="mydocker",
+                   var="DOCKER_CONFIG",
+                   path="/root/.docker/config"
+               )
+            ]
+        ),
+    ]

--- a/tests/instructions/script/.cirrus.expected.yml
+++ b/tests/instructions/script/.cirrus.expected.yml
@@ -13,3 +13,10 @@ task:
   multiple_script:
     - echo "step 1"
     - echo "step 2"
+task:
+  name: background script
+  container:
+    cpu: 2
+    memory: 4096
+  start_emulator_background_script:
+    - emulator -avd test -no-audio -no-window

--- a/tests/instructions/script/.cirrus.expected.yml
+++ b/tests/instructions/script/.cirrus.expected.yml
@@ -14,9 +14,21 @@ task:
     - echo "step 1"
     - echo "step 2"
 task:
+  name: unnamed script
+  container:
+    cpu: 2
+    memory: 4096
+  script: echo "step 1"
+task:
   name: background script
   container:
     cpu: 2
     memory: 4096
   start_emulator_background_script:
     - emulator -avd test -no-audio -no-window
+task:
+  name: unnamed background script
+  container:
+    cpu: 2
+    memory: 4096
+  background_script: emulator -avd test -no-audio -no-window

--- a/tests/instructions/script/.cirrus.star
+++ b/tests/instructions/script/.cirrus.star
@@ -1,4 +1,4 @@
-load("../../../lib.star", "task", "container", "script")
+load("../../../lib.star", "task", "container", "script", "background")
 
 def main(ctx):
     return [
@@ -8,4 +8,7 @@ def main(ctx):
         task("script instruction with multiple commands", container(), instructions=[
             script("multiple", "echo \"step 1\"", "echo \"step 2\"")
         ]),
+        task("background script", container(), instructions=[
+            background("start_emulator", "emulator -avd test -no-audio -no-window")
+        ])
     ]

--- a/tests/instructions/script/.cirrus.star
+++ b/tests/instructions/script/.cirrus.star
@@ -8,7 +8,13 @@ def main(ctx):
         task("script instruction with multiple commands", container(), instructions=[
             script("multiple", "echo \"step 1\"", "echo \"step 2\"")
         ]),
+        task("unnamed script", container(), instructions=[
+            script("echo \"step 1\"")
+        ]),
         task("background script", container(), instructions=[
             background("start_emulator", "emulator -avd test -no-audio -no-window")
+        ]),
+        task("unnamed background script", container(), instructions=[
+            background("emulator -avd test -no-audio -no-window")
         ])
     ]

--- a/tests/macos_instance/.cirrus.expected.yml
+++ b/tests/macos_instance/.cirrus.expected.yml
@@ -1,0 +1,4 @@
+task:
+  name: macos task
+  macos_instance:
+    image: big-sur-xcode

--- a/tests/macos_instance/.cirrus.star
+++ b/tests/macos_instance/.cirrus.star
@@ -1,0 +1,6 @@
+load("../../lib.star", "task", "macos_instance")
+
+def main(ctx):
+    return [
+        task("macos task", macos_instance("big-sur-xcode")),
+    ]

--- a/tests/windows_container/.cirrus.expected.yml
+++ b/tests/windows_container/.cirrus.expected.yml
@@ -1,0 +1,13 @@
+task:
+  name: task default windows container
+  windows_container:
+    image: cirrusci/windowsservercore
+task:
+  name: task custom windows container
+  windows_container:
+    image: cirrusci/windowsservercore:visualstudio2019
+task:
+  name: task custom windows container custom version
+  windows_container:
+    image: python:3.8-windowsservercore
+    os_version: "2019"

--- a/tests/windows_container/.cirrus.expected.yml
+++ b/tests/windows_container/.cirrus.expected.yml
@@ -11,3 +11,5 @@ task:
   windows_container:
     image: python:3.8-windowsservercore
     os_version: "2019"
+  debug_script:
+    - ps: Get-Location

--- a/tests/windows_container/.cirrus.expected.yml
+++ b/tests/windows_container/.cirrus.expected.yml
@@ -13,3 +13,10 @@ task:
     os_version: "2019"
   debug_script:
     - ps: Get-Location
+task:
+  name: task with unnamed powershell script
+  windows_container:
+    image: python:3.8-windowsservercore
+    os_version: "2019"
+  script:
+    - ps: Get-Location

--- a/tests/windows_container/.cirrus.star
+++ b/tests/windows_container/.cirrus.star
@@ -1,4 +1,4 @@
-load("../../lib.star", "task", "windows_container")
+load("../../lib.star", "task", "windows_container", "powershell")
 
 def main(ctx):
     return [
@@ -6,5 +6,6 @@ def main(ctx):
         task("task custom windows container",
              windows_container("cirrusci/windowsservercore:visualstudio2019")),
         task("task custom windows container custom version",
-             windows_container("python:3.8-windowsservercore", "2019")),
+             windows_container("python:3.8-windowsservercore", "2019"),
+             instructions=[powershell("debug", "Get-Location")])
     ]

--- a/tests/windows_container/.cirrus.star
+++ b/tests/windows_container/.cirrus.star
@@ -1,0 +1,10 @@
+load("../../lib.star", "task", "windows_container")
+
+def main(ctx):
+    return [
+        task("task default windows container", windows_container()),
+        task("task custom windows container",
+             windows_container("cirrusci/windowsservercore:visualstudio2019")),
+        task("task custom windows container custom version",
+             windows_container("python:3.8-windowsservercore", "2019")),
+    ]

--- a/tests/windows_container/.cirrus.star
+++ b/tests/windows_container/.cirrus.star
@@ -7,5 +7,8 @@ def main(ctx):
              windows_container("cirrusci/windowsservercore:visualstudio2019")),
         task("task custom windows container custom version",
              windows_container("python:3.8-windowsservercore", "2019"),
-             instructions=[powershell("debug", "Get-Location")])
+             instructions=[powershell("debug", "Get-Location")]),
+        task("task with unnamed powershell script",
+             windows_container("python:3.8-windowsservercore", "2019"),
+             instructions=[powershell("Get-Location")])
     ]


### PR DESCRIPTION
The [docs](https://cirrus-ci.org/guide/programming-tasks/#writing-starlark-scripts) seem to indicate that `script` helpers can be invoked with only one argument, as shown in the example (taken from the docs):

```python
task(
    instance=container("debian:latest"),
    instructions=[script("make")]
)
```

This PR tries to implement the documented behaviour.

---
Sorry guys I wrote this PR on top of #4. Please let me know if you would prefer to have something just for the `script` helper and not use the extra helpers introduced in #4.
