### PR TITLE
Add pipe directive

### DIFF
--- a/lib.star
+++ b/lib.star
@@ -18,6 +18,29 @@ def task(name, instance, env={}, instructions=[], depends_on=[], alias=""):
     return result
 
 
+def pipe(name, steps=(), resources=None):
+    """Create a Docker Pipe that executes each instruction in its own container
+    https://cirrus-ci.org/guide/docker-pipe/
+
+    `steps` should be a dict: each key is a Docker image name its associated
+    value is a list of instructions. When repeated images are required an
+    equivalent list of 2-tuples, (similar to `dict.items()`) can also be used.
+    """
+    spec = {'name': name}
+    if resources != None:
+        spec['resources'] = resources
+
+    steps_list = steps.items() if type(steps) == "dict" else steps
+    spec['steps'] = []
+    for image, instructions in steps_list:
+        step = {'image': image}
+        items = [instructions] if type(instructions) != "list" else instructions
+        for item in items:
+            step.update(item)
+        spec['steps'].append(step)
+    return {'pipe': spec}
+
+
 def cache(name, folder, fingerprint_script=[], populate_script=[]):
     cache_obj = {'folder': folder}
     if len(fingerprint_script) > 0:

--- a/tests/pipe/.cirrus.expected.yml
+++ b/tests/pipe/.cirrus.expected.yml
@@ -1,0 +1,14 @@
+pipe:
+  name: Build Site and Validate Links
+  resources:
+    cpu: 2.5
+    memory: 5G
+  steps:
+    - image: squidfunk/mkdocs-material:latest
+      build_script:
+        - mkdocs build
+    - image: raviqqe/liche:latest
+      validate_script:
+        - /liche --document-root=site --recursive site/
+      finish_script:
+        - echo DONE

--- a/tests/pipe/.cirrus.star
+++ b/tests/pipe/.cirrus.star
@@ -1,0 +1,14 @@
+load("../../lib.star", "pipe", "script")
+
+def main():
+    return pipe(
+        "Build Site and Validate Links",
+        resources={"cpu": 2.5, "memory": "5G"},
+        steps={
+            "squidfunk/mkdocs-material:latest": script("build", "mkdocs build"),
+            "raviqqe/liche:latest": [
+                script("validate", "/liche --document-root=site --recursive site/"),
+                script("finish", "echo DONE"),
+            ]
+        }
+    )


### PR DESCRIPTION
This PR is inspired by the docker pipes supported by Cirrus.

The idea here is that a user could just `return pipe(...)` from main for simple CI scripts...

On the downside: currently it would not be trivial to combine `pipe(...)` with a list of tasks, since this PR implements `pipe` as a nested dict with a [root `"pipe"` key](https://stackoverflow.com/questions/18411145/root-object-or-no-what-is-the-best-practice-for-api-responses), but the `task(...)` helper returns a dict without a root key.