### PR TITLE
Add `arm_container` to support Linux arm64 builds

### DIFF
--- a/lib.star
+++ b/lib.star
@@ -108,8 +108,7 @@ def file_from_env(var, path, name=""):
     }
 
 
-def container(image="", dockerfile="", cpu=2.0, memory=4096, **kwargs):
-    """https://cirrus-ci.org/guide/linux"""
+def _container(arm=False, image="", dockerfile="", cpu=2.0, memory=4096, **kwargs):
     result = dict()
     if image != "":
         result['image'] = image
@@ -119,8 +118,18 @@ def container(image="", dockerfile="", cpu=2.0, memory=4096, **kwargs):
     result['memory'] = memory
     result.update(kwargs)
     return {
-        'container': result
+        ('arm_container' if arm else 'container'): result
     }
+
+
+def container(*args, **kwargs):
+    """https://cirrus-ci.org/guide/linux"""
+    return _container(False, *args, **kwargs)
+
+
+def arm_container(*args, **kwargs):
+    """https://cirrus-ci.org/guide/linux"""
+    return _container(True, *args, **kwargs)
 
 
 def windows_container(image="cirrusci/windowsservercore", os_version="", **kwargs):

--- a/tests/arm_container/.cirrus.expected.yml
+++ b/tests/arm_container/.cirrus.expected.yml
@@ -1,0 +1,22 @@
+task:
+  name: task with a default ARM container
+  arm_container:
+    cpu: 2
+    memory: 4096
+task:
+  name: task with a container instantiated from debian:latest image
+  arm_container:
+    image: debian:latest
+    cpu: 2
+    memory: 4096
+task:
+  name: task with a container built from Dockerfile
+  arm_container:
+    dockerfile: ./ci/Dockerfile
+    cpu: 2
+    memory: 4096
+task:
+  name: task with a high-performance container
+  arm_container:
+    cpu: 16
+    memory: 16384

--- a/tests/arm_container/.cirrus.star
+++ b/tests/arm_container/.cirrus.star
@@ -1,0 +1,9 @@
+load("../../lib.star", "task", "arm_container")
+
+def main(ctx):
+    return [
+        task("task with a default ARM container", arm_container()),
+        task("task with a container instantiated from debian:latest image", arm_container("debian:latest")),
+        task("task with a container built from Dockerfile", arm_container(dockerfile="./ci/Dockerfile")),
+        task("task with a high-performance container", arm_container(cpu=16, memory=16384)),
+    ]


### PR DESCRIPTION
The documentation for Linux containers details both amd64 and arm64 but this Starlark module only provided support for `container`, which meant that there was no convenient analogue for `arm_container` in YAML for repositories using Starlark.

cc @fkorotkov, apologies for the ping but it looks like no one is following this repo so I figured it's likely this PR wouldn't get seen otherwise.